### PR TITLE
fix: Use peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     },
     "testRegex": "(/src/.*\\.(spec.ts))$"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@angular/core": "^8.1.1",
     "rxjs": "^6.5.2",
     "zone.js": "~0.9.1"


### PR DESCRIPTION
These are not private dependencies, as they are used by Angular and any Angular project.
As it is now you risk installing a second version of these packages in a node_modules folder of the library itself.
Then you get errors like:
` Type Observable is not assignable to type Observable`

