### PR TITLE
support multiple instance usages of @Changes decorator

### DIFF
--- a/src/decorators/decorators.spec.ts
+++ b/src/decorators/decorators.spec.ts
@@ -176,6 +176,41 @@ describe('on Changes decorator', () => {
     });
   });
 
+  it('should support multiple usages', () => {
+    class MyComponent implements OnChanges {
+      @Changes('foo') foo$;
+      @Changes('bar') bar$;
+
+      ngOnChanges(changes: SimpleChanges): void {
+      }
+    }
+
+    const instance = new MyComponent();
+    const simpleChanges = {
+      foo: {
+        currentValue: [1, 2, 3],
+        previousValue: undefined
+      }
+    };
+    const simpleChanges2 = {
+      bar: {
+        currentValue: [4, 5, 6],
+        previousValue: undefined
+      }
+    };
+
+    instance.ngOnChanges(simpleChanges as any);
+    instance.ngOnChanges(simpleChanges2 as any);
+
+    const fooResults = [];
+    const barResults = [];
+    instance.foo$.subscribe(change => fooResults.push(change));
+    instance.bar$.subscribe(change => barResults.push(change));
+
+    expect(fooResults[0]).toEqual(simpleChanges.foo.currentValue);
+    expect(barResults[0]).toEqual(simpleChanges2.bar.currentValue);
+  });
+
   it('should handle multiple instances', () => {
     class MyComponent implements OnChanges {
       @Changes('foo') foo$;

--- a/src/decorators/decorators.ts
+++ b/src/decorators/decorators.ts
@@ -84,10 +84,7 @@ export function Changes(inputProp?: string, initialValue?: any) {
     function getStream() {
       const subject = new ReplaySubject(1);
       return inputProp
-        ? subject.pipe(
-          filter(changes => !!changes && changes[inputProp]),
-          map(changes => changes[inputProp].currentValue)
-        )
+        ? subject.pipe(map(changes => changes[inputProp].currentValue))
         : subject;
     }
 
@@ -127,7 +124,9 @@ export function Changes(inputProp?: string, initialValue?: any) {
       if (oldNgOnChanges) {
         oldNgOnChanges.apply(this, [simpleChanges]);
       }
-      this[accessor].next(simpleChanges);
+      if(!inputProp || simpleChanges[inputProp]) {
+        this[accessor].next(simpleChanges);
+      }
     };
   };
 }


### PR DESCRIPTION
I noticed having multiple usages of the @Changes('x') decorator had some unexpected outcomes. 

To showcase the problem I created a [stackblitz project](https://stackblitz.com/edit/angular-i3mhk8), here we have two @Changes('x') usages and both should have a **final value of '2'** but instead only the very first has it. 

Narrowed it down to the replaySubject holding the incorrect (IMO) value, to support this I added some unit tests that would fail with the previous implementation. 
  


